### PR TITLE
* Issue #3 pass through non frame item types: and Issue#2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! 
 //! 
 pub mod mikumari_format {
+    pub const MIKUMARI_FRAME_ITEM_TYPE: u32=51;
     use std::io::Read;
     use std::io;
     // Data type values:

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use rust_ringitem_format::{RingItem};
 use frib_datasource::{data_sink_factory, DataSink};
 
 
-const MIKUMARI_FRAME_ITEM_TYPE: u32=51;
 const HEART_BEAT_MICROSECONDS : f64 = 524.288; // Time between heart beats.
 const TDC_TICK_PS : f64 = 0.9765625;           // LSB value for tdc.
 fn main() ->std::io::Result<()> {
@@ -82,7 +81,7 @@ fn dump_data(src : &mut mikumari_format::MikumariReader, t0 : u64, rf : &mut Box
     // start a ring item for the first frame:
 
     let mut ring_item = RingItem::new_with_body_header(
-        MIKUMARI_FRAME_ITEM_TYPE,
+        mikumari_format::MIKUMARI_FRAME_ITEM_TYPE,
         hb_frame_to_ts(frame_no) as u64,
         0, 0
      );
@@ -105,7 +104,7 @@ fn dump_data(src : &mut mikumari_format::MikumariReader, t0 : u64, rf : &mut Box
                 // Start the new ring item:
 
                 ring_item = RingItem::new_with_body_header(
-                    MIKUMARI_FRAME_ITEM_TYPE,
+                    mikumari_format::MIKUMARI_FRAME_ITEM_TYPE,
                     hb_frame_to_ts(frame_no) as u64,
                     0,0
                 );


### PR DESCRIPTION
*  Move the MIKUMARI_FRAME_ITEM_TYPE into the format library.
*  Just write any non mikumari fram in convert_item.
*  Actually Issue #2 but flush the sink at the end of convert_item, no matter what was written.
Resolves issue #2  and issue #3 

All of this sets the ground work for the mikumarimaker to emit begin/end runs.